### PR TITLE
Enable multiple returned generations

### DIFF
--- a/llm_client/__init__.py
+++ b/llm_client/__init__.py
@@ -44,7 +44,7 @@ class Client:
         Returns:
         """
         if isinstance(text, str):
-            return self.prompt([text], max_new_tokens, **kwargs)[0]
+            return self.prompt([text], max_new_tokens, **kwargs)
 
         # TODO: Check for max length limit to avoid OOMs
 


### PR DESCRIPTION
It worked before, but since the recent changes - this change is required to have multiple returned generations using:
```python
client.prompt("CMU's PhD students are", num_beams=4, num_return_sequences=4, do_sample=True)
```