### PR TITLE
fix hidden states and scores not being returned

### DIFF
--- a/llm_client/__init__.py
+++ b/llm_client/__init__.py
@@ -55,7 +55,9 @@ class Client:
         Returns:
         """
         if isinstance(text, str):
-            return self.prompt([text], max_new_tokens, output_scores, output_hidden_states, **kwargs)
+            return self.prompt(
+                [text], max_new_tokens, output_scores, output_hidden_states, **kwargs
+            )
 
         # TODO: Check for max length limit to avoid OOMs
 

--- a/llm_client/__init__.py
+++ b/llm_client/__init__.py
@@ -55,7 +55,7 @@ class Client:
         Returns:
         """
         if isinstance(text, str):
-            return self.prompt([text], max_new_tokens, **kwargs)
+            return self.prompt([text], max_new_tokens, output_scores, output_hidden_states, **kwargs)
 
         # TODO: Check for max length limit to avoid OOMs
 


### PR DESCRIPTION
I tried to get hidden states and scores from llama the other day but they weren't being returned. I think this is because of the arguments being overridden when there's a string input.

To test, do `outputs = client.prompt("hello", output_scores=True, output_hidden_states=True)`. You should see scores and hidden states.
